### PR TITLE
Do not wait for new 2FA code on successful login

### DIFF
--- a/filecloudapi/fcserver.py
+++ b/filecloudapi/fcserver.py
@@ -180,13 +180,6 @@ class FCServer:
                 },
             )
 
-            ok = int(resp.findtext("./command/result", "0")) == 1
-
-            if ok:
-                # We need a new code for the next login
-                while code == self.twofakeyfun():
-                    time.sleep(1)
-
         self._raise_exception_from_command(resp)
 
     def login_as_admin(self) -> None:
@@ -219,13 +212,6 @@ class FCServer:
                     "password": self.password,
                 },
             )
-
-            ok = int(resp.findtext("./command/result", "0")) == 1
-
-            if ok:
-                # We need a new code for the next login
-                while code == self.twofakeyfun():
-                    time.sleep(1)
 
         self._raise_exception_from_command(resp)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "filecloudapi-python"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python library to connect to a Filecloud server"
 
 packages = [{ include = "filecloudapi" }]


### PR DESCRIPTION
Because we use TOTP 2FA in testing we were waiting for a new 2FA code after successful login. Remove
this now it is a generic library